### PR TITLE
correct GDAS oro configuration for chgres

### DIFF
--- a/compare_lsmask_c384.py
+++ b/compare_lsmask_c384.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import numpy as np
+from netCDF4 import Dataset
+
+ifname_gdas     = '/scratch2/NCEPDEV/stmp1/Zhichang.Guo/Work/Temp2/change_res/C384_ORIG/2025051421/mem001/sfc_data.nc'
+ifname_20230615 = '/scratch1/NCEPDEV/global/glopara/fix/orog/20230615/C384/sfc/C384.vegetation_type.nc'
+ifname_20231027 = '/scratch1/NCEPDEV/global/glopara/fix/orog/20231027/C384/sfc/C384.mx025.vegetation_type.nc'
+ifname_20240917 = '/scratch1/NCEPDEV/global/glopara/fix/orog/20240917/C384/sfc/C384.mx025.vegetation_type.nc'
+
+land_locations_gdas     = 0
+land_locations_20230615 = 0
+land_locations_20231027 = 0
+land_locations_20240917 = 0
+same_gdas_20230615      = True
+same_20231027_20240917  = True
+
+for itile in range(1, 7):
+    fname_gdas     = ifname_gdas.replace('.nc','.tile'+str(itile)+'.nc')
+    fname_20230615 = ifname_20230615.replace('.nc','.tile'+str(itile)+'.nc')
+    fname_20231027 = ifname_20231027.replace('.nc','.tile'+str(itile)+'.nc')
+    fname_20240917 = ifname_20240917.replace('.nc','.tile'+str(itile)+'.nc')
+
+    ncid_gdas     = Dataset(fname_gdas, 'r')
+    ncid_20230615 = Dataset(fname_20230615, 'r')
+    ncid_20231027 = Dataset(fname_20231027, 'r')
+    ncid_20240917 = Dataset(fname_20240917, 'r')
+
+    vtype_gdas     = ncid_gdas.variables['vtype'][0, :, :]               #vegetation_type used for Noah
+    vtype_20230615 = ncid_20230615.variables['vegetation_type'][0, :, :] #vegetation_type used for NoahMP
+    vtype_20231027 = ncid_20231027.variables['vegetation_type'][0, :, :]
+    vtype_20240917 = ncid_20240917.variables['vegetation_type'][0, :, :]
+
+    vtype_water = 17
+
+    ndims = vtype_gdas.shape
+    for idim0 in range(ndims[0]):
+        for idim1 in range(ndims[1]):
+            lsmask_gdas     = 0
+            lsmask_20230615 = 0
+            ivtype_20231027 = 0
+            ivtype_20240917 = 0
+            if vtype_gdas[idim0, idim1] > 0.5:
+                land_locations_gdas += 1
+                lsmask_gdas = 1 
+            if vtype_20230615[idim0, idim1] > 0.5 and int(round(vtype_20230615[idim0, idim1])) != vtype_water:
+                land_locations_20230615 += 1
+                lsmask_20230615 = 1
+            if vtype_20231027[idim0, idim1] > 0.5 and int(round(vtype_20231027[idim0, idim1])) != vtype_water:
+                land_locations_20231027 += 1
+                ivtype_20231027 = int(round(vtype_20231027[idim0, idim1]))
+            if vtype_20240917[idim0, idim1] > 0.5 and int(round(vtype_20240917[idim0, idim1])) != vtype_water:
+                land_locations_20240917 += 1
+                ivtype_20240917 = int(round(vtype_20240917[idim0, idim1]))
+            if lsmask_gdas != lsmask_20230615:
+                same_gdas_20230615 = False
+                print(idim0, idim1, itile, lsmask_gdas, lsmask_20230615)
+            if ivtype_20231027 != ivtype_20240917:
+                same_20231027_20240917 = False
+                print(idim0, idim1, itile, ivtype_20231027, ivtype_20240917)
+    ncid_gdas.close()
+    ncid_20230615.close()
+    ncid_20231027.close()
+    ncid_20240917.close()
+if same_gdas_20230615:
+    print("land-sea mask is same between GDAS C384 and version 20230615 C384")
+else:
+    print("land-sea mask is different between GDAS C384 and version 20230615 C384")
+if same_20231027_20240917:
+    print("vegetation mask is same between 20231027 C384 and 20240917 C384")
+else:
+    print("vegetation mask is different between 20231027 C384 and 20240917 C384")
+print("Land locations for GDAS C384:     ",land_locations_gdas)
+print("Land locations for 20230615 C384: ",land_locations_gdas)
+print("Land locations for 20231027 C384: ",land_locations_20231027)
+print("Land locations for 20240917 C384: ",land_locations_20240917)

--- a/config_control.nml.template
+++ b/config_control.nml.template
@@ -7,7 +7,7 @@
  orog_files_input_grid="C768.mx025_oro_data.tile1.nc","C768.mx025_oro_data.tile2.nc","C768.mx025_oro_data.tile3.nc","C768.mx025_oro_data.tile4.nc","C768.mx025_oro_data.tile5.nc","C768.mx025_oro_data.tile6.nc"
  orog_dir_target_grid="/scratch1/NCEPDEV/global/glopara/fix/orog/20231027/C<RES>"
  orog_files_target_grid="C<RES>.mx025_oro_data.tile1.nc","C<RES>.mx025_oro_data.tile2.nc","C<RES>.mx025_oro_data.tile3.nc","C<RES>.mx025_oro_data.tile4.nc","C<RES>.mx025_oro_data.tile5.nc","C<RES>.mx025_oro_data.tile6.nc"
- data_dir_input_grid="<CHNGRESDIR>/C768/<YYYYMMDD><HH>/<member>"
+ data_dir_input_grid="<CHNGRESDIR>/C768_ORIG/<YYYYMMDD><HH>/<member>"
  atm_core_files_input_grid="fv_core.res.tile1.nc","fv_core.res.tile2.nc","fv_core.res.tile3.nc","fv_core.res.tile4.nc","fv_core.res.tile5.nc","fv_core.res.tile6.nc","fv_core.res.nc"
  atm_tracer_files_input_grid="fv_tracer.res.tile1.nc","fv_tracer.res.tile2.nc","fv_tracer.res.tile3.nc","fv_tracer.res.tile4.nc","fv_tracer.res.tile5.nc","fv_tracer.res.tile6.nc"
  sfc_files_input_grid="sfc_data.tile1.nc","sfc_data.tile2.nc","sfc_data.tile3.nc","sfc_data.tile4.nc","sfc_data.tile5.nc","sfc_data.tile6.nc"

--- a/config_ens.nml.template
+++ b/config_ens.nml.template
@@ -1,13 +1,13 @@
 
 &config
  mosaic_file_target_grid="/scratch1/NCEPDEV/global/glopara/fix/orog/20231027/C<RES>/C<RES>_mosaic.nc"
- mosaic_file_input_grid="/scratch1/NCEPDEV/global/glopara/fix/orog/20231027/C384/C384_mosaic.nc"
+ mosaic_file_input_grid="/scratch1/NCEPDEV/global/glopara/fix/orog/20230615/C384/C384_mosaic.nc"
  fix_dir_target_grid="/scratch1/NCEPDEV/global/glopara/fix/orog/20231027/C<RES>/sfc"
- orog_dir_input_grid="/scratch1/NCEPDEV/global/glopara/fix/orog/20231027/C384"
- orog_files_input_grid="C384.mx025_oro_data.tile1.nc","C384.mx025_oro_data.tile2.nc","C384.mx025_oro_data.tile3.nc","C384.mx025_oro_data.tile4.nc","C384.mx025_oro_data.tile5.nc","C384.mx025_oro_data.tile6.nc"
+ orog_dir_input_grid="/scratch1/NCEPDEV/global/glopara/fix/orog/20230615/C384"
+ orog_files_input_grid="C384_oro_data.tile1.nc","C384_oro_data.tile2.nc","C384_oro_data.tile3.nc","C384_oro_data.tile4.nc","C384_oro_data.tile5.nc","C384_oro_data.tile6.nc"
  orog_dir_target_grid="/scratch1/NCEPDEV/global/glopara/fix/orog/20231027/C<RES>"
  orog_files_target_grid="C<RES>.mx025_oro_data.tile1.nc","C<RES>.mx025_oro_data.tile2.nc","C<RES>.mx025_oro_data.tile3.nc","C<RES>.mx025_oro_data.tile4.nc","C<RES>.mx025_oro_data.tile5.nc","C<RES>.mx025_oro_data.tile6.nc"
- data_dir_input_grid="<CHNGRESDIR>/C384/<YYYYMMDD><HH>/<member>"
+ data_dir_input_grid="<CHNGRESDIR>/C384_ORIG/<YYYYMMDD><HH>/<member>"
  atm_core_files_input_grid="fv_core.res.tile1.nc","fv_core.res.tile2.nc","fv_core.res.tile3.nc","fv_core.res.tile4.nc","fv_core.res.tile5.nc","fv_core.res.tile6.nc","fv_core.res.nc"
  atm_tracer_files_input_grid="fv_tracer.res.tile1.nc","fv_tracer.res.tile2.nc","fv_tracer.res.tile3.nc","fv_tracer.res.tile4.nc","fv_tracer.res.tile5.nc","fv_tracer.res.tile6.nc"
  sfc_files_input_grid="sfc_data.tile1.nc","sfc_data.tile2.nc","sfc_data.tile3.nc","sfc_data.tile4.nc","sfc_data.tile5.nc","sfc_data.tile6.nc"

--- a/config_restarts
+++ b/config_restarts
@@ -21,7 +21,9 @@ RES_CTL=192
 
 RES_ENS_IN=384 # NOTE: these are hard-wired in chres nml.template files
 RES_CTL_IN=768
-#arch_tag="v16.2" # Yanjun
+#arch_tag="v16.3" # 20221129 and after 20221129
+#arch_tag="v16.2" # 20220627 - 20221128 Yanjun
+#arch_tag="prod"  # 20220626 and before 20220626
 arch_tag="v16.3" # will depend on time period
 
 UFS_UTILS=${HERE}/UFS_UTILS/

--- a/get_restarts.sh
+++ b/get_restarts.sh
@@ -15,8 +15,8 @@ source config_restarts
 mkdir -p $WORKDIR
 mkdir -p $CHNGRESDIR/C${RES_ENS}/${VALID_DATE}
 mkdir -p $CHNGRESDIR/C${RES_CTL}/${VALID_DATE}
-mkdir -p $CHNGRESDIR/C${RES_ENS_IN}/${VALID_DATE}
-mkdir -p $CHNGRESDIR/C${RES_CTL_IN}/${VALID_DATE}
+mkdir -p $CHNGRESDIR/C${RES_ENS_IN}_ORIG/${VALID_DATE}
+mkdir -p $CHNGRESDIR/C${RES_CTL_IN}_ORIG/${VALID_DATE}
 
 
 datestring="${YYYYMMDDp3}.${HHp3}0000."
@@ -32,7 +32,7 @@ htar -xvf $hpsspath/com_gfs_${arch_tag}_gdas.${YYYYMMDD}_${HH}.gdas_restart.tar
 
 # copy required files
 
-OUTDIR=$CHNGRESDIR/C${RES_CTL_IN}/${VALID_DATE}
+OUTDIR=$CHNGRESDIR/C${RES_CTL_IN}_ORIG/${VALID_DATE}
 /bin/cp -f gdas.${YYYYMMDD}/${HH}/atmos/gdas.t${HH}z.abias $OUTDIR/gdas.t${HHp3}z.abias
 /bin/cp -f gdas.${YYYYMMDD}/${HH}/atmos/gdas.t${HH}z.abias_pc $OUTDIR/gdas.t${HHp3}z.abias_pc
 /bin/cp -f gdas.${YYYYMMDD}/${HH}/atmos/gdas.t${HH}z.abias_air $OUTDIR/gdas.t${HHp3}z.abias_air
@@ -61,7 +61,7 @@ while [ $ngrp -le $ngrps ]; do
      charnanal="mem`printf %03i $nanal`"
      pushd enkfgdas.${YYYYMMDD}/${HH}/atmos/${charnanal}/RESTART
      n=$((n+1))
-     OUTDIR=$CHNGRESDIR/C${RES_ENS_IN}/${VALID_DATE}/${charnanal}
+     OUTDIR=$CHNGRESDIR/C${RES_ENS_IN}_ORIG/${VALID_DATE}/${charnanal}
      mkdir $OUTDIR
      for file in ${datestring}*nc; do
         file2=`echo $file | cut -f3-10 -d"."`


### PR DESCRIPTION
1. Add a python script "compare_lsmask_c384.py" to find the correct version of fixed grid files for orog and land-sea mask;
2. Using the python script "compare_lsmask_c384.py", the correct orog grid version can be found to be 20230615. The corresponding change has been made in config_ens.nml.template; the orog grid version for the control should be checked too;
3. Since the latest C384 orog grid version for GFS/GEFS is different from that in GDAS C384. So the ensemble restart files may need to be regridded from the 20230615 C384 version to another C384 version which have a different land-sea mask, and changes have been made to store the downloaded files at the directory change_res/C384_ORIG, and store the regridded files at the directory such as change_res/C384.