### PR TITLE
Clear up snow and soil liquid water perturbations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Insert a spun-up (vector) land restart into cold start tile files.
 Also applies the ensemble pertubations from the operational ensemble into the ensemble of tile files. 
 
 Inserts, soil moisture (total and liquid), soil temperature, snow depth (and SWE), and snow water equivalent from the spin up.
-Inserts pertubations in soil moisture, soil temperature and snow depth (and SWE). 
+Inserts pertubations in soil moisture and soil temperature. 
 
 To-do: think some more about snow temperature.
      : parallelize the python calls.

--- a/replace_soil_snow.py
+++ b/replace_soil_snow.py
@@ -134,7 +134,7 @@ for n in range(0,n_ens):
                             max_val[0,l] = max(max_val[0,l],tile_smc[0, l, idim0, idim1] - orig)
 
                             orig = tile_slc[0, l, idim0, idim1]
-                            tile_slc[0, l, idim0, idim1] = max(smc_min, vec_slc[l, nloc] + pert_slc[0, l, idim0, idim1])
+                            tile_slc[0, l, idim0, idim1] = max(smc_min, vec_slc[l, nloc])
                             min_val[1,l] = min(min_val[1,l],tile_slc[0, l, idim0, idim1] - orig)
                             max_val[1,l] = max(max_val[1,l],tile_slc[0, l, idim0, idim1] - orig)
 

--- a/replace_soil_snow.py
+++ b/replace_soil_snow.py
@@ -83,12 +83,12 @@ for n in range(0,n_ens):
             ncid = Dataset(ensmean_file)
 
             # pert = ensemble value - mean
-            pert_slc = tile_slc - ncid.variables['slc'][:]
+            pert_smc = tile_smc - ncid.variables['smc'][:]
             pert_stc = tile_stc - ncid.variables['stc'][:]
 
         else:
 
-            pert_slc = np.full(np.shape(tile_slc),0.0)
+            pert_smc = np.full(np.shape(tile_smc),0.0)
             pert_stc = np.full(np.shape(tile_stc),0.0)
 
         for idim0 in range(ndims[0]):
@@ -128,7 +128,7 @@ for n in range(0,n_ens):
                         # note: potentially allowing soil moisture above porosity. I think the model fixes this.
                         for l in np.arange(4):
                             orig = tile_smc[0, l, idim0, idim1]
-                            tile_smc[0, l, idim0, idim1] = max(smc_min, vec_smc[l, nloc] + pert_slc[0, l, idim0, idim1])
+                            tile_smc[0, l, idim0, idim1] = max(smc_min, vec_smc[l, nloc] + pert_smc[0, l, idim0, idim1])
 
                             min_val[0,l] = min(min_val[0,l],tile_smc[0, l, idim0, idim1] - orig)
                             max_val[0,l] = max(max_val[0,l],tile_smc[0, l, idim0, idim1] - orig)


### PR DESCRIPTION
@ClaraDraper-NOAA 
1. Removed snow-related perturbation sentences in README;
2. No longer perturb soil liquid content in replace_soil_snow.py;
3. Perturb soil moisture contents (SMC) with SMC rather than SLC (soil liquid contents) perturbations.